### PR TITLE
Add support for python 3.9

### DIFF
--- a/pyspamsum.c
+++ b/pyspamsum.c
@@ -7,6 +7,8 @@
  * Copyright 2009 Russell Keith-Magee <russell@keith-magee.com>
  */
 
+#define PY_SSIZE_T_CLEAN
+
 #include <Python.h>
 #include <sys/types.h>
 #include <stdio.h>
@@ -33,7 +35,7 @@ PyObject *py_edit_distance(PyObject *self, PyObject *args)
     int distance;
 
     char *from, *to;
-    int from_len, to_len;
+    Py_ssize_t from_len, to_len;
 
     if (!PyArg_ParseTuple(args, "s#s#", &from, &from_len, &to, &to_len))
     {
@@ -53,7 +55,7 @@ PyObject *py_spamsum(PyObject *self, PyObject *args)
     char *sum;
 
     unsigned char *in;
-    unsigned int length;
+    Py_ssize_t length;
     unsigned int flags, bsize;
 
     flags = 0;

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ with io.open('README.rst', encoding='utf8') as readme:
 
 setup(
     name="pyspamsum",
-    version="1.0.4",
+    version="1.0.5",
     description="A Python wrapper for Andrew Tridgell's spamsum algorithm",
     long_description=long_description,
     author="Russell Keith-Magee",
@@ -27,6 +27,9 @@ setup(
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
         'Topic :: Text Processing',
         'Topic :: Utilities',
     ],


### PR DESCRIPTION
As is, it fails with:
```
>>> import spamsum
>>> spamsum.spamsum('somestring')
DeprecationWarning: PY_SSIZE_T_CLEAN will be required for '#' formats

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
SystemError: <built-in function spamsum> returned a result with an error set
>>> 
```
After the fix:
```
Python 3.9.0 (default, Oct 16 2020, 09:21:06) 
[GCC 8.3.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import spamsum
>>> spamsum.spamsum('somestring')
'3:yp:yp'
```
I've included a version bump (as well as updated classifiers) as an optional commit.
Note that I've tested this on Python2.7 and Python 3.9 only.
