### PR TITLE
Switch to cibuildwheel for CI builds.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+  workflow_call:
 
 # Cancel active CI runs for a PR before starting another run
 concurrency:
@@ -25,26 +26,45 @@ jobs:
   unit-tests:
     name: Unit tests
     needs: [ pre-commit ]
-    runs-on: ${{ matrix.platform }}
-    continue-on-error: ${{ matrix.experimental || false }}
+    runs-on: ${{ matrix.runs-on }}
     strategy:
       fail-fast: false
       matrix:
-        platform: [ "macos-13", "macos-latest", "ubuntu-24.04" ]
-        # Test the min and max stable Python version on each OS.
-        python-version: [ "3.9", "3.13" ]
+        name: [ "macOS (x86_64)", "macOS (arm64)", "iOS", "Linux (x86_64)", "Linux (arm64)" ] # Android, Windows (x86_64), Windows (arm64)
         include:
-          # Ensure the Python versions between min and max are tested
-          - platform: "ubuntu-24.04"
-            python-version: "3.10"
-          - platform: "ubuntu-24.04"
-            python-version: "3.11"
-          - platform: "ubuntu-24.04"
-            python-version: "3.12"
-          # Allow dev Python to fail without failing entire job
-          - platform: "ubuntu-24.04"
-            python-version: "3.14"
-            experimental: true
+          - name: macOS (x86_64)
+            platform: macos
+            runs-on: macos-13
+            archs: auto
+          - name: macOS (arm64)
+            platform: macos
+            runs-on: macos-latest
+            archs: auto,universal2
+          - name: iOS
+            platform: ios
+            runs-on: macos-latest
+            archs: auto
+          - name: Linux (x86_64)
+            platform: linux
+            runs-on: ubuntu-24.04
+            archs: auto
+          - name: Linux (arm64)
+            platform: linux
+            runs-on: ubuntu-24.04-arm
+            archs: auto
+          # - name: Android
+          #   platform: android
+          #   runs-on: macos-latest
+          #   archs: auto
+          # - name: Windows (x86_64)
+          #   platform: windows
+          #   runs-on: windows-latest
+          #   archs: auto
+          # - name: Windows (arm64)
+          #   platform: windows
+          #   runs-on: windows-latest-arm??
+          #   archs: auto
+
     steps:
     - name: Checkout
       uses: actions/checkout@v4.2.2
@@ -54,16 +74,23 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v5.4.0
       with:
-        python-version: ${{ matrix.python-version }}
-        allow-prereleases: true
+        python-version: "3.x"
 
-    - name: Install Tox
-      uses: beeware/.github/.github/actions/install-requirement@main
-      with:
-        requirements: tox
-        extra: dev
-
-    - name: Test
-      id: test
+    - name: Install cibuildwheel
       run: |
-        tox -e py
+        python -m pip install -U pip
+        # Use a branch while iOS support is in development and test-sources is unpublished.
+        # python -m pip install cibuildwheel==3.0.0
+        python -m pip install git+https://github.com/freakboy3742/cibuildwheel.git@ios-support
+
+    - name: Build wheels
+      run: python -m cibuildwheel
+      env:
+        CIBW_PLATFORM: ${{ matrix.platform }}
+        CIBW_ARCHS: ${{ matrix.archs }}
+        CIBW_BUILD: "cp*"
+
+    - uses: actions/upload-artifact@v4.6.0
+      with:
+        name: wheels-${{ matrix.name }}
+        path: ./wheelhouse/*.whl

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,6 +83,12 @@ jobs:
         # python -m pip install cibuildwheel==3.0.0
         python -m pip install git+https://github.com/freakboy3742/cibuildwheel.git@ios-support
 
+    - name: iOS testing set workaround
+      if: matrix.platform == 'ios'
+      run: |
+        # Temp workaround - make sure there is an iOS test devices directory
+        mkdir -p /Users/runner/Library/Developer/XCTestDevices
+
     - name: Build wheels
       run: python -m cibuildwheel
       env:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,22 @@
+name: Upload Python Package
+
+on:
+  release:
+    types: published
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    permissions:
+      # This permission is required for trusted publishing.
+      id-token: write
+    steps:
+      - uses: dsaltares/fetch-gh-release-asset@1.1.2
+        with:
+          version: tags/${{ github.event.release.tag_name }}
+          file: ${{ github.event.repository.name }}.*
+          regex: true
+          target: dist/
+
+      - name: Publish release to production PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1.12.3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,54 @@
+name: Create Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  ci:
+    name: CI
+    uses: ./.github/workflows/ci.yml
+
+  release:
+    name: Create Release
+    needs: ci
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      # This permission is required for trusted publishing.
+      id-token: write
+      attestations: write
+    steps:
+      - name: Set build variables
+        run: |
+          echo "VERSION=${GITHUB_REF_NAME#v}" | tee -a $GITHUB_ENV
+
+      - name: Set up Python
+        uses: actions/setup-python@v5.4.0
+        with:
+          python-version: "3.x"
+
+      - name: Get packages
+        uses: actions/download-artifact@v4.1.8
+        with:
+          pattern: wheels-*
+          path: dist
+
+      - name: Create release
+        uses: ncipollo/release-action@v1.15.0
+        with:
+          name: ${{ env.VERSION }}
+          draft: true
+          artifacts: dist/*
+          artifactErrorsFailBuild: true
+
+      - name: Generate attestations
+        uses: actions/attest-build-provenance@v2.1.0
+        with:
+          subject-path: "dist/*"
+
+      # - name: Publish release to Test PyPI
+      #   uses: pypa/gh-action-pypi-publish@release/v1
+      #   with:
+      #     repository-url: https://test.pypi.org/legacy/

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ distribute-*
 .tox/
 .vscode/
 venv/
+wheelhouse/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,9 +38,11 @@ classifiers=[
 [project.optional-dependencies]
 # Extras used by developers *of* briefcase are pinned to specific versions to
 # ensure environment consistency.
+test = [
+    "pytest == 8.3.4",
+]
 dev = [
     "pre-commit == 4.1.0",
-    "pytest == 8.3.4",
     "ruff == 0.9.6",
     "setuptools_scm == 8.1.0",
     "tox == 4.24.1",
@@ -53,6 +55,7 @@ Source = "https://github.com/freakboy3742/pyspamsum/"
 
 [tool.cibuildwheel]
 test-command = "pytest"
+test-extras = ["test"]
 test-sources = ["tests"]
 
 [tool.pytest.ini_options]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,6 @@ classifiers=[
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
-    "Programming Language :: Python :: 3.14",
     "Topic :: Text Processing",
     "Topic :: Utilities",
 ]
@@ -51,6 +50,10 @@ dev = [
 Homepage = "https://github.com/freakboy3742/pyspamsum/"
 Tracker = "https://github.com/freakboy3742/pyspamsum/issues"
 Source = "https://github.com/freakboy3742/pyspamsum/"
+
+[tool.cibuildwheel]
+test-command = "pytest"
+test-sources = ["tests"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/tox.ini
+++ b/tox.ini
@@ -10,6 +10,6 @@ commands = pre-commit run --all-files --show-diff-on-failure --color=always
 
 [testenv:py{,39,310,311,312,313,314}]
 depends = pre-commit
-extras = dev
+extras = test
 commands =
     python -m pytest {posargs:-vv --color yes}


### PR DESCRIPTION
* Use cibuildwheel to build and test wheels
* Add a publication and release workflow (with test-pypi uploads disabled for now)